### PR TITLE
Switch to using pi_fm_rds to transmit RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The result? A Raspberry Pi broadcasting a single song and an accompanying websit
 
 ## What’s Inside?
 
-- **FM Radio**: Broadcast a single `.wav` file using a Raspberry Pi.
+- **FM Transmitter**: Broadcast a single `.wav` file using a Raspberry Pi.
 - **AWS Integration**: Store and retrieve playlist data with DynamoDB and Lambda.
-- **Retro Website**: Display your station’s playlist in an eye-catching 90s design.
+- **Retro Website**: Display your station’s playlist in an eye-~~burning~~catching 90s design.
 
 ### How It Works
 1. The Raspberry Pi transmits a `.wav` file as an FM signal and posts the song details to AWS.
@@ -24,12 +24,12 @@ The result? A Raspberry Pi broadcasting a single song and an accompanying websit
 ---
 
 ## Features
-- Broadcast a single song in `.wav` format.
+- FM Broadcast a single song in `.wav` format, and related RDS information.
 - Automatically log song details (artist, title, duration) via AWS Lambda.
 - Display the last five songs played on the website.
 
 **Heads Up!**
-1. **Cost Alert**: Hosting the website on AWS incurs a small cost (~$1/month in low-traffic scenarios). Ensure you’re comfortable with potential expenses before proceeding.
+1. **Cost Alert**: Hosting the website on AWS incurs a small cost (~$1/month in low-traffic scenarios). Ensure you’re comfortable with potential expenses before proceeding.  I'm paying $0.50/month for Route53, and $0.04/month for everything else = $0.54 total/month.  I pay $14/year for brightshinyradio.com domain registration as well.
 2. **Legal Compliance**: Ensure broadcasting FM signals is legal in your region.
 3. The installer script disables HDMI on your raspberry pi to save energy.  Delete the line "/usr/bin/tvservice -o" from /etc/rc.local and reboot to turn it back on.
 ---
@@ -124,3 +124,5 @@ Got questions or need help? Check out the [documentation](https://github.com/jas
 [Convertio](https://convertio.co/) For generating the .ico file
 
 [Thomas Vanhoutte](https://thomas.vanhoutte.be/miniblog/how-much-energy-does-a-raspberry-pi-use-per-year-cost-calculation/)'s blog post on energy saving
+
+[Wikipedia](https://en.wikipedia.org/wiki/Radio_Data_System) for their RDS writeup

--- a/pi/install-pi-software.sh
+++ b/pi/install-pi-software.sh
@@ -50,8 +50,7 @@ CONFIG_FILE="player.ini"
 cat > "$CONFIG_FILE" <<EOF
 [settings]
 FREQUENCY="87.1" # The FM frequency to broadcast.
-STATION_CODE="iBSR" # The station code to broadcast.
-STATION_NAME="BSRadio" # The station name to broadcast, limit 8 characters.
+STATION_NAME="MYRADIO" # The station name to broadcast, limit 8 characters.
 ARTIST="Favorite Band" # The artist of song.wav
 TITLE="Greatest song ever" # The title of song.wav
 DURATION=270 # Length of song.wav in seconds

--- a/pi/install-pi-software.sh
+++ b/pi/install-pi-software.sh
@@ -5,31 +5,32 @@
 printf "###\n"
 printf "### Perform updates\n\n"
 
-sudo apt-get update \
+sudo apt-get update && sudo apt-get upgrade --yes\
 || exit_on_error "Failed to perform updates"
 
 printf "\n\n###\n"
 printf "### Install required libraries for the fm transmitter\n\n"
 
-sudo apt-get install make build-essential && \
-sudo apt-get install libraspberrypi-dev --yes \
-|| exit_on_error "Failed to perform updates"
+sudo apt install libsndfile1-dev --yes \
+|| exit_on_error "Failed to install required libraries"
 
 printf "\n\n###\n"
-printf "### Install the fm_transmitter\n"
+printf "### Install PiFmRds transmitter\n"
 
-curl -sL https://github.com/markondej/fm_transmitter/archive/refs/heads/master.zip --output fm_transmitter.zip
-unzip fm_transmitter.zip
-cd fm_transmitter-master
-make
-mv fm_transmitter ~/
+curl -sL https://github.com/ChristopheJacquet/PiFmRds/archive/refs/heads/master.zip --output PiFmRds.zip
+unzip PiFmRds.zip
+cd PiFmRds-master/src
+make clean && make \
+|| exit_on_error "Failed to make PiFmRds"
+
+mv pi_fm_rds ~/pi_fm_rds
 cd ~/
 
 printf "\n\n###\n"
-printf "### Clean up the fm_transmitter source\n"
+printf "### Clean up the PiFmRds source\n"
 
-rm fm_transmitter.zip
-rm -rf fm_transmitter-master
+rm PiFmRds.zip
+rm -rf PiFmRds-master
 
 printf "\n\n###\n"
 printf "### Copy the player script and make it executable\n"
@@ -49,6 +50,8 @@ CONFIG_FILE="player.ini"
 cat > "$CONFIG_FILE" <<EOF
 [settings]
 FREQUENCY="87.1" # The FM frequency to broadcast.
+STATION_CODE="iBSR" # The station code to broadcast.
+STATION_NAME="BSRadio" # The station name to broadcast, limit 8 characters.
 ARTIST="Favorite Band" # The artist of song.wav
 TITLE="Greatest song ever" # The title of song.wav
 DURATION=270 # Length of song.wav in seconds

--- a/pi/player.sh
+++ b/pi/player.sh
@@ -18,6 +18,8 @@ fi
 
 echo "Using configuration:"
 echo "Broadcasting on Frequency: $FREQUENCY"
+echo "RDS Station Code: $STATION_CODE"
+echo "RDS Station Name: $STATION_NAME"
 echo "Artist: $ARTIST"
 echo "Title: $TITLE"
 echo "Duration: $DURATION seconds"
@@ -26,6 +28,8 @@ echo "API security token: $API_KEY"
 
 ## Gracefully exit with a message if any variable is unset.
 : ${FREQUENCY:?Must set FREQUENCY.}
+: ${STATION_CODE:?Must set STATION_CODE.}
+: ${STATION_NAME:?Must set STATION_NAME.}
 : ${ARTIST:?Must set ARTIST.}
 : ${TITLE:?Must set TITLE.}
 : ${DURATION:?Must set DURATION.}
@@ -47,6 +51,6 @@ do
       -d "{\"artist\": \"$ARTIST\", \"title\": \"$TITLE\", \"duration\": $DURATION}" \
       "$API_URL"
 
-  sudo ./fm_transmitter -f $FREQUENCY song.wav
+  sudo ./pi_fm_rds -freq $FREQUENCY -audio song.wav -pi $STATION_CODE -ps $STATION_NAME -rt "$ARTIST - $TITLE"
 
 done

--- a/pi/player.sh
+++ b/pi/player.sh
@@ -18,7 +18,6 @@ fi
 
 echo "Using configuration:"
 echo "Broadcasting on Frequency: $FREQUENCY"
-echo "RDS Station Code: $STATION_CODE"
 echo "RDS Station Name: $STATION_NAME"
 echo "Artist: $ARTIST"
 echo "Title: $TITLE"
@@ -28,7 +27,6 @@ echo "API security token: $API_KEY"
 
 ## Gracefully exit with a message if any variable is unset.
 : ${FREQUENCY:?Must set FREQUENCY.}
-: ${STATION_CODE:?Must set STATION_CODE.}
 : ${STATION_NAME:?Must set STATION_NAME.}
 : ${ARTIST:?Must set ARTIST.}
 : ${TITLE:?Must set TITLE.}
@@ -51,6 +49,6 @@ do
       -d "{\"artist\": \"$ARTIST\", \"title\": \"$TITLE\", \"duration\": $DURATION}" \
       "$API_URL"
 
-  sudo ./pi_fm_rds -freq $FREQUENCY -audio song.wav -pi $STATION_CODE -ps $STATION_NAME -rt "$ARTIST - $TITLE"
+  sudo ./pi_fm_rds -freq $FREQUENCY -audio song.wav -ps "$STATION_NAME" -rt "$ARTIST - $TITLE"
 
 done


### PR DESCRIPTION
Change fm transmitter application to a version that also broadcasts Radio Data System data, and add RDS metadata to the player.ini config file and player.sh command arguments.